### PR TITLE
Blacked Out User Selection within Dropdown Menus on Ubuntu

### DIFF
--- a/src/openstudio_lib/openstudiolib.qss
+++ b/src/openstudio_lib/openstudiolib.qss
@@ -107,6 +107,9 @@ QComboBox {
     padding-right: 10px;
     padding-top: 1px;
     color: black;
+    background-color: white;
+    selection-color: white;
+    selection-background-color: darkblue;
 }
 
 QComboBox:!editable, QComboBox::drop-down:editable {

--- a/src/openstudio_lib/openstudiolib.qss
+++ b/src/openstudio_lib/openstudiolib.qss
@@ -109,7 +109,7 @@ QComboBox {
     color: black;
     background-color: white;
     selection-color: white;
-    selection-background-color: darkblue;
+    selection-background-color: gray;
 }
 
 QComboBox:!editable, QComboBox::drop-down:editable {


### PR DESCRIPTION
Fix #67. See screenshots on https://github.com/NREL/OpenStudioApplication/issues/67#issuecomment-580206262

I've tried `darkblue` first, but I don't really like it, so I tried `gray`, which I like better. Do you have an opinion @eomere?

![darkblue](https://user-images.githubusercontent.com/5479063/73445020-1a903f00-435a-11ea-85f5-4ae42d325263.png)

![gray](https://user-images.githubusercontent.com/5479063/73445132-51feeb80-435a-11ea-8078-f1a53ea896b6.png)

