### PR TITLE
#79 - Refrigeration Grid should be declared unavailable for all but "Refigeration"

### DIFF
--- a/src/openstudio_lib/HVACSystemsController.cpp
+++ b/src/openstudio_lib/HVACSystemsController.cpp
@@ -385,9 +385,10 @@ void HVACSystemsController::update()
       }
       else
       {
-          m_hvacControlsController = std::shared_ptr<HVACControlsController>(new HVACControlsController(this));
+        // Not allowed
+        m_hvacControlsController = std::shared_ptr<HVACControlsController>(new HVACControlsController(this));
 
-          m_hvacSystemsView->mainViewSwitcher->setView(m_hvacControlsController->noControlsView());
+        m_hvacSystemsView->mainViewSwitcher->setView(m_hvacControlsController->noControlsView());
       }
     }
     else if( handle == VRF )
@@ -401,14 +402,21 @@ void HVACSystemsController::update()
 
         m_hvacSystemsView->mainViewSwitcher->setView(m_vrfController->vrfView());
       }
+      else if( m_hvacSystemsView->hvacToolbarView->gridViewButton->isChecked() )
+      {
+        // Not allowed: Refrigeration only on Refrigeration tab
+        m_refrigerationController = std::shared_ptr<RefrigerationController>(new RefrigerationController());
+
+        m_hvacSystemsView->mainViewSwitcher->setView(m_refrigerationController->noRefrigerationView());
+      }
       else
       {
-          m_hvacControlsController = std::shared_ptr<HVACControlsController>(new HVACControlsController(this));
+        m_hvacControlsController = std::shared_ptr<HVACControlsController>(new HVACControlsController(this));
 
-          m_hvacSystemsView->mainViewSwitcher->setView(m_hvacControlsController->noControlsView());
+        m_hvacSystemsView->mainViewSwitcher->setView(m_hvacControlsController->noControlsView());
       }
     }
-    else
+    else  // NOT VRF NOR REFRIGERATION
     {
       if( m_hvacSystemsView->hvacToolbarView->topologyViewButton->isChecked() )
       {
@@ -422,14 +430,10 @@ void HVACSystemsController::update()
       }
       else if( m_hvacSystemsView->hvacToolbarView->gridViewButton->isChecked() )
       {
-        // TODO
-        m_refrigerationGridController = std::shared_ptr<RefrigerationGridController>(new RefrigerationGridController(m_isIP, m_model));
+        // Not allowed: Refrigeration only on Refrigeration tab
+        m_refrigerationController = std::shared_ptr<RefrigerationController>(new RefrigerationController());
 
-        connect(this, &HVACSystemsController::toggleUnitsClicked, m_refrigerationGridController.get()->refrigerationGridView(), &RefrigerationGridView::toggleUnitsClicked);
-
-        connect(this, &HVACSystemsController::toggleUnitsClicked, this, &HVACSystemsController::toggleUnits);
-
-        m_hvacSystemsView->mainViewSwitcher->setView(m_refrigerationGridController->refrigerationGridView());
+        m_hvacSystemsView->mainViewSwitcher->setView(m_refrigerationController->noRefrigerationView());
       }
       else
       {

--- a/src/openstudio_lib/RefrigerationController.cpp
+++ b/src/openstudio_lib/RefrigerationController.cpp
@@ -228,6 +228,8 @@ RefrigerationController::RefrigerationController()
 
   m_refrigerationGridScene->addItem(m_refrigerationSystemGridView);
 
+  m_noRefrigerationView = new NoRefrigerationView();
+
   zoomOutToSystemGridView();
 }
 
@@ -236,6 +238,9 @@ RefrigerationController::~RefrigerationController()
   delete m_refrigerationView;
 
   delete m_refrigerationScene;
+
+  delete m_noRefrigerationView;
+
 }
 
 boost::optional<model::RefrigerationSystem> RefrigerationController::supplySystem(const model::RefrigerationCondenserCascade & condenser)
@@ -704,6 +709,11 @@ void RefrigerationController::refreshNow()
 RefrigerationView * RefrigerationController::refrigerationView() const
 {
   return m_refrigerationView;
+}
+
+NoRefrigerationView * RefrigerationController::noRefrigerationView() const
+{
+  return m_noRefrigerationView;
 }
 
 void RefrigerationController::inspectOSItem(const OSItemId & itemid)

--- a/src/openstudio_lib/RefrigerationController.hpp
+++ b/src/openstudio_lib/RefrigerationController.hpp
@@ -50,6 +50,7 @@ class RefrigerationScene;
 class RefrigerationSystemDetailView;
 class OSItemId;
 class RefrigerationView;
+class NoRefrigerationView;
 // TODO class RefrigerationGridView;
 
 class RefrigerationController : public QObject
@@ -63,6 +64,8 @@ class RefrigerationController : public QObject
   virtual ~RefrigerationController();
 
   RefrigerationView * refrigerationView() const;
+
+  NoRefrigerationView * noRefrigerationView() const;
 
   // TODO RefrigerationGridView * refrigerationGridView() const;
 
@@ -126,6 +129,8 @@ class RefrigerationController : public QObject
   QSharedPointer<QGraphicsScene> m_refrigerationGridScene;
 
   QPointer<QGraphicsScene> m_refrigerationScene;
+
+  QPointer<NoRefrigerationView> m_noRefrigerationView;
 
   bool m_dirty;
 

--- a/src/openstudio_lib/RefrigerationGraphicsItems.cpp
+++ b/src/openstudio_lib/RefrigerationGraphicsItems.cpp
@@ -1537,4 +1537,23 @@ void CaseViewExpandButton::paint(QPainter *painter,
   }
 }
 
+NoRefrigerationView::NoRefrigerationView()
+  : QWidget()
+{
+  auto mainVLayout = new QVBoxLayout();
+  mainVLayout->setContentsMargins(5,5,5,5);
+  mainVLayout->setSpacing(10);
+  mainVLayout->setAlignment(Qt::AlignTop);
+  setLayout(mainVLayout);
+
+  QLabel * label = new QLabel("Refrigeration options are only available for Refrigeration systems.");
+  label->setWordWrap(true);
+  label->setObjectName("H1");
+  mainVLayout->addWidget(label);
+}
+
+NoRefrigerationView::~NoRefrigerationView()
+{
+}
+
 } // openstudio

--- a/src/openstudio_lib/RefrigerationGraphicsItems.hpp
+++ b/src/openstudio_lib/RefrigerationGraphicsItems.hpp
@@ -771,6 +771,16 @@ class RefrigerationSecondaryView : public QGraphicsObject
   int m_height;
 };
 
+// A class to display that Refrigeration isn't allowed on that tab
+class NoRefrigerationView : public QWidget
+{
+  public:
+
+  NoRefrigerationView();
+
+  virtual ~NoRefrigerationView();
+};
+
 } // openstudio
 
 #endif // OPENSTUDIO_REFRIGERATIONGRAPHICSITEMS_HPP


### PR DESCRIPTION
Fix #79 

Demo:

Any tab that isn't the Refrigeration one:

![image](https://user-images.githubusercontent.com/5479063/76803405-0dc88d00-67da-11ea-8f66-041441980223.png)


The refrigeration one: business as usual

![image](https://user-images.githubusercontent.com/5479063/76803481-3cdefe80-67da-11ea-9393-998a1a099702.png)

----

This is the same as the existing behavior for the control tab that is limited to AirLoopHVAC & PlantLoops

![image](https://user-images.githubusercontent.com/5479063/76803549-6b5cd980-67da-11ea-8baa-35774e35a0fb.png)

