### PR TITLE
Fix #80 - need to showControls when switching tabs

### DIFF
--- a/src/openstudio_lib/HVACSystemsController.cpp
+++ b/src/openstudio_lib/HVACSystemsController.cpp
@@ -347,6 +347,9 @@ void HVACSystemsController::update()
     m_hvacSystemsView->hvacToolbarView->addButton->show();
     m_hvacSystemsView->hvacToolbarView->deleteButton->show();
 
+    // Show Controls, to avoid still displaying the name of a previously selected "Water Use Connection" object for eg
+    m_hvacSystemsView->hvacToolbarView->showControls(true);
+
     m_hvacLayoutController.reset();
     m_hvacControlsController.reset();
     m_refrigerationController.reset();


### PR DESCRIPTION
Fix #80 - need to showControls when switching tabs.

As often, fix is dead simple, the problem is tracking down the cause and knowing where/when to apply it.

Demo:

![80_WaterUseConnection_Label](https://user-images.githubusercontent.com/5479063/76968200-ca306900-6928-11ea-9e57-81d4fe8ef53f.gif)
