### PR TITLE
Enable MP builds and link to ruby lib for bindings (Windows)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,6 +230,13 @@ endif()
 ###############################################################################
 # Compiler and system specific options
 
+if(MSVC AND NOT NINJA)
+  # Build with Multiple Processes
+  set(BUILD_WITH_MULTIPLE_PROCESSES ON CACHE BOOL "/MP compiler flag for full processor utilization")
+  mark_as_advanced(BUILD_WITH_MULTIPLE_PROCESSES)
+endif()
+
+
 if(UNIX)
 
   #set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -fPIC -fno-strict-aliasing")
@@ -337,6 +344,8 @@ if(UNIX AND NOT APPLE)
   )
   message(STATUS "LSB_RELEASE_ID_SHORT = ${LSB_RELEASE_ID_SHORT}")
 endif()
+
+
 
 ###############################################################################
 #                           D E P E N D E N C I E S                           #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -650,7 +650,12 @@ install(DIRECTORY "${OPENSTUDIO_SDK_PATH}/EnergyPlus" DESTINATION "." COMPONENT 
 install(DIRECTORY "${OPENSTUDIO_SDK_PATH}/Examples" DESTINATION "." COMPONENT "OpenStudioApp" USE_SOURCE_PERMISSIONS)
 
 install(PROGRAMS ${os_cli_location} DESTINATION bin COMPONENT "CLI" RENAME "${os_cli_install_name}")
-install(PROGRAMS "${OPENSTUDIO_SDK_PATH}/bin/install_utility" DESTINATION bin COMPONENT "CLI")
+
+if(WIN32)
+  install(PROGRAMS "${OPENSTUDIO_SDK_PATH}/bin/install_utility.exe" DESTINATION bin COMPONENT "CLI")
+else()
+  install(PROGRAMS "${OPENSTUDIO_SDK_PATH}/bin/install_utility" DESTINATION bin COMPONENT "CLI")
+endif()
 
 
 set(CPACK_PACKAGE_VENDOR "National Renewable Energy Laboratory")

--- a/ruby/CMakeLists.txt
+++ b/ruby/CMakeLists.txt
@@ -81,6 +81,8 @@ target_link_libraries(openstudio_modeleditor_rb
 )
 
 if( WIN32 )
+  include("${OPENSTUDIO_SDK_PATH}/lib/cmake/openstudio/FetchRubyMinGW.cmake")
+  FetchRubyMinGW()
   target_link_libraries(openstudio_modeleditor_rb ${RUBY_MINGW_STUB_LIB})
 endif()
 

--- a/src/bimserver/CMakeLists.txt
+++ b/src/bimserver/CMakeLists.txt
@@ -33,7 +33,6 @@ if(WIN32)
 endif()
 
 add_library(${target_name} ${${target_name}_src})
-#target_compile_definitions(${target_name} PRIVATE ${target_name}_EXPORTS PUBLIC SHARED_OSAPP_LIBS)
 target_link_libraries(${target_name} ${${target_name}_depends})
 AddPCH(${target_name})
 

--- a/src/model_editor/CMakeLists.txt
+++ b/src/model_editor/CMakeLists.txt
@@ -130,8 +130,6 @@ add_library(${target_name}
   ${${target_name}_uis}
 )
 
-# target_compile_definitions(${target_name} PRIVATE ${target_name}_EXPORTS PUBLIC SHARED_OS_LIBS)
-
 # lib dependencies
 set(${target_name}_depends
   openstudio::openstudiolib

--- a/src/openstudio_lib/CMakeLists.txt
+++ b/src/openstudio_lib/CMakeLists.txt
@@ -716,8 +716,6 @@ add_library(${target_name}
   ${${target_name}_qrcs}
 )
 
-#target_compile_definitions(${target_name} PRIVATE ${target_name}_EXPORTS PUBLIC SHARED_OS_LIBS)
-
 set(depends
   openstudio_modeleditor
   openstudio::openstudiolib

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -29,7 +29,6 @@ set(${target_name}_depends
 add_library(${target_name}
   ${${target_name}_src}
 )
-#target_compile_definitions(${target_name} PRIVATE ${target_name}_EXPORTS PUBLIC SHARED_OSAPP_LIBS)
 target_link_libraries(${target_name} ${${target_name}_depends} )
 
 


### PR DESCRIPTION
 - Dramatically speed up Windows builds by enabling multi process builds
 - Utilize OpenStudio's Ruby MinGW Fetch script to get mingw ruby lib
 files for linking with MSVC