### PR TITLE
Fix #65 - Download progress bar cleared when finished downloading

### DIFF
--- a/src/shared_gui_components/BuildingComponentDialogCentralWidget.cpp
+++ b/src/shared_gui_components/BuildingComponentDialogCentralWidget.cpp
@@ -268,8 +268,8 @@ void BuildingComponentDialogCentralWidget::lowerPushButtonClicked()
 
       if (m_filterType == "components")
       {
-        // DLM: replace with Nano Signal
-        //connect(remoteBCL, &RemoteBCL::componentDownloaded, this, &BuildingComponentDialogCentralWidget::componentDownloadComplete);
+        // Connect to Nano Signal
+        remoteBCL->componentDownloaded.connect<BuildingComponentDialogCentralWidget, &BuildingComponentDialogCentralWidget::componentDownloadComplete>(const_cast<BuildingComponentDialogCentralWidget *>(this));
 
         bool downloadStarted = remoteBCL->downloadComponent(component->uid());
         if (downloadStarted){
@@ -294,8 +294,8 @@ void BuildingComponentDialogCentralWidget::lowerPushButtonClicked()
       }
       else if (m_filterType == "measures")
       {
-        // DLM: replace with Nano Signal
-        //connect(remoteBCL, &RemoteBCL::measureDownloaded, this, &BuildingComponentDialogCentralWidget::measureDownloadComplete);
+        // Connect to Nano Signal
+        remoteBCL->measureDownloaded.connect<BuildingComponentDialogCentralWidget, &BuildingComponentDialogCentralWidget::measureDownloadComplete>(const_cast<BuildingComponentDialogCentralWidget *>(this));
 
         bool downloadStarted = remoteBCL->downloadMeasure(component->uid());
         if (downloadStarted){

--- a/src/shared_gui_components/BuildingComponentDialogCentralWidget.hpp
+++ b/src/shared_gui_components/BuildingComponentDialogCentralWidget.hpp
@@ -35,6 +35,7 @@
 #include <set>
 #include <vector>
 
+#include <openstudio/nano/nano_signal_slot.hpp> // Signal-Slot replacement
 #include <boost/optional.hpp>
 
 class QProgressBar;
@@ -47,7 +48,7 @@ class Component;
 class ComponentList;
 class CollapsibleComponentList;
 
-class BuildingComponentDialogCentralWidget : public QWidget
+class BuildingComponentDialogCentralWidget : public QWidget, public Nano::Observer
 {
   Q_OBJECT
 


### PR DESCRIPTION
Fix #65 by connecting the `RemoteBCL::componentDownloaded` nano signal with the Qt slot `BuildingComponentDialogCentralWidget::componentDownloadComplete` (an same for Measures)

FYI #66 is fixed on OpenStudio's side via https://github.com/NREL/OpenStudio/pull/3934