### PR TITLE
Fix #97 - Properly register the OS:Construction:AirBoundary in OS App

### DIFF
--- a/src/openstudio_lib/ConstructionsController.cpp
+++ b/src/openstudio_lib/ConstructionsController.cpp
@@ -36,6 +36,7 @@
 #include <openstudio/model/ComponentData.hpp>
 #include <openstudio/model/ComponentData_Impl.hpp>
 #include <openstudio/model/Construction.hpp>
+#include <openstudio/model/ConstructionAirBoundary.hpp>
 #include <openstudio/model/ConstructionBase.hpp>
 #include <openstudio/model/ConstructionBase_Impl.hpp>
 #include <openstudio/model/ConstructionWithInternalSource.hpp>
@@ -63,6 +64,9 @@ void ConstructionsController::onAddObject(const openstudio::IddObjectType& iddOb
   switch(iddObjectType.value()){
     case IddObjectType::OS_Construction:
       openstudio::model::Construction(this->model());
+      break;
+    case IddObjectType::OS_Construction_AirBoundary:
+      openstudio::model::ConstructionAirBoundary(this->model());
       break;
     case IddObjectType::OS_Construction_InternalSource:
       openstudio::model::ConstructionWithInternalSource(this->model());

--- a/src/openstudio_lib/ConstructionsView.cpp
+++ b/src/openstudio_lib/ConstructionsView.cpp
@@ -32,6 +32,7 @@
 #include "ConstructionCfactorUndergroundWallInspectorView.hpp"
 #include "ConstructionFfactorGroundFloorInspectorView.hpp"
 #include "ConstructionInspectorView.hpp"
+#include "ConstructionAirBoundaryInspectorView.hpp"
 #include "ConstructionInternalSourceInspectorView.hpp"
 #include "ConstructionWindowDataFileInspectorView.hpp"
 #include "ModelObjectTypeListView.hpp"
@@ -60,6 +61,7 @@ std::vector<std::pair<IddObjectType, std::string> > ConstructionsView::modelObje
 {
   std::vector<std::pair<IddObjectType, std::string> > result;
   result.push_back(std::make_pair<IddObjectType, std::string>(IddObjectType::OS_Construction, "Constructions"));
+  result.push_back(std::make_pair<IddObjectType, std::string>(IddObjectType::OS_Construction_AirBoundary, "Air Boundary Constructions"));
   result.push_back(std::make_pair<IddObjectType, std::string>(IddObjectType::OS_Construction_InternalSource, "Internal Source Constructions"));
   result.push_back(std::make_pair<IddObjectType, std::string>(IddObjectType::OS_Construction_CfactorUndergroundWall, "C-factor Underground Wall Constructions"));
   result.push_back(std::make_pair<IddObjectType, std::string>(IddObjectType::OS_Construction_FfactorGroundFloor, "F-factor Ground Floor Constructions"));
@@ -99,6 +101,9 @@ void ConstructionsInspectorView::onSelectModelObject(const openstudio::model::Mo
     case IddObjectType::OS_Construction:
       this->showConstructionInspector(modelObject);
       break;
+    case IddObjectType::OS_Construction_AirBoundary:
+      this->showAirBoundaryInspector(modelObject);
+      break;
     case IddObjectType::OS_Construction_CfactorUndergroundWall:
       this->showCfactorUndergroundWallInspector(modelObject);
       break;
@@ -124,6 +129,16 @@ void ConstructionsInspectorView::showConstructionInspector(const openstudio::mod
   constructionInspectorView->selectModelObject(modelObject);
 
   this->showInspector(constructionInspectorView);
+}
+
+void ConstructionsInspectorView::showAirBoundaryInspector(const openstudio::model::ModelObject & modelObject)
+{
+  auto constructionAirBoundaryInspectorView = new ConstructionAirBoundaryInspectorView(m_isIP, m_model);
+  connect(this, &ConstructionsInspectorView::toggleUnitsClicked, constructionAirBoundaryInspectorView, &ConstructionAirBoundaryInspectorView::toggleUnitsClicked);
+
+  constructionAirBoundaryInspectorView->selectModelObject(modelObject);
+
+  this->showInspector(constructionAirBoundaryInspectorView);
 }
 
 void ConstructionsInspectorView::showCfactorUndergroundWallInspector(const openstudio::model::ModelObject & modelObject)

--- a/src/openstudio_lib/ConstructionsView.hpp
+++ b/src/openstudio_lib/ConstructionsView.hpp
@@ -79,6 +79,8 @@ class ConstructionsInspectorView : public ModelObjectInspectorView
 
     void showConstructionInspector(const openstudio::model::ModelObject & modelObject);
 
+    void showAirBoundaryInspector(const openstudio::model::ModelObject & modelObject);
+
     void showCfactorUndergroundWallInspector(const openstudio::model::ModelObject & modelObject);
 
     void showFfactorGroundFloorInspector(const openstudio::model::ModelObject & modelObject);

--- a/src/openstudio_lib/IconLibrary.cpp
+++ b/src/openstudio_lib/IconLibrary.cpp
@@ -229,6 +229,7 @@ IconLibrary::IconLibrary()
   m_miniIcons[openstudio::IddObjectType(openstudio::IddObjectType::OS_Building).value()] = new QPixmap(":images/mini_icons/building.png");
   m_miniIcons[openstudio::IddObjectType(openstudio::IddObjectType::OS_BuildingStory).value()] = new QPixmap(":images/mini_icons/building_story.png");
   m_miniIcons[openstudio::IddObjectType(openstudio::IddObjectType::OS_Construction).value()] = new QPixmap(":images/mini_icons/construction.png");
+  m_miniIcons[openstudio::IddObjectType(openstudio::IddObjectType::OS_Construction_AirBoundary).value()] = new QPixmap(":images/mini_icons/construction_air_boundary.png");
   m_miniIcons[openstudio::IddObjectType(openstudio::IddObjectType::OS_Construction_CfactorUndergroundWall).value()] = new QPixmap(":images/mini_icons/construction_undergnd.png");
   m_miniIcons[openstudio::IddObjectType(openstudio::IddObjectType::OS_Construction_FfactorGroundFloor).value()] = new QPixmap(":images/mini_icons/construction_gnd.png");
   m_miniIcons[openstudio::IddObjectType(openstudio::IddObjectType::OS_Construction_InternalSource).value()] = new QPixmap(":images/mini_icons/construct_inter_source.png");

--- a/src/openstudio_lib/MainRightColumnController.cpp
+++ b/src/openstudio_lib/MainRightColumnController.cpp
@@ -390,6 +390,7 @@ void MainRightColumnController::configureForConstructionsSubTab(int subTabID)
       myModelList->addModelObjectType(IddObjectType::OS_Construction_FfactorGroundFloor, "F-factor Ground Floor Constructions");
       myModelList->addModelObjectType(IddObjectType::OS_Construction_CfactorUndergroundWall, "C-factor Underground Wall Constructions");
       myModelList->addModelObjectType(IddObjectType::OS_Construction_InternalSource, "Internal Source Constructions");
+      myModelList->addModelObjectType(IddObjectType::OS_Construction_AirBoundary, "Air Boundary Constructions");
       myModelList->addModelObjectType(IddObjectType::OS_Construction, "Constructions");
 
       setMyModelView(myModelList);
@@ -405,6 +406,7 @@ void MainRightColumnController::configureForConstructionsSubTab(int subTabID)
       myLibraryList->addModelObjectType(IddObjectType::OS_Construction_FfactorGroundFloor, "F-factor Ground Floor Constructions");
       myLibraryList->addModelObjectType(IddObjectType::OS_Construction_CfactorUndergroundWall, "C-factor Underground Wall Constructions");
       myLibraryList->addModelObjectType(IddObjectType::OS_Construction_InternalSource, "Internal Source Constructions");
+      myLibraryList->addModelObjectType(IddObjectType::OS_Construction_AirBoundary, "Air Boundary Constructions");
       myLibraryList->addModelObjectType(IddObjectType::OS_Construction, "Constructions");
       myLibraryList->addModelObjectType(IddObjectType::OS_DefaultConstructionSet, "Construction Sets");
 
@@ -476,6 +478,7 @@ void MainRightColumnController::configureForConstructionsSubTab(int subTabID)
       myLibraryList->addModelObjectType(IddObjectType::OS_Construction_FfactorGroundFloor, "F-factor Ground Floor Constructions");
       myLibraryList->addModelObjectType(IddObjectType::OS_Construction_CfactorUndergroundWall, "C-factor Underground Wall Constructions");
       myLibraryList->addModelObjectType(IddObjectType::OS_Construction_InternalSource, "Internal Source Constructions");
+      myLibraryList->addModelObjectType(IddObjectType::OS_Construction_AirBoundary, "Air Boundary Constructions");
       myLibraryList->addModelObjectType(IddObjectType::OS_Construction, "Constructions");
 
       setLibraryView(myLibraryList);
@@ -580,6 +583,7 @@ void MainRightColumnController::configureForLoadsSubTab(int subTabID)
   myModelList->addModelObjectType(IddObjectType::OS_Construction_FfactorGroundFloor, "F-factor Ground Floor Constructions");
   myModelList->addModelObjectType(IddObjectType::OS_Construction_CfactorUndergroundWall, "C-factor Underground Wall Constructions");
   myModelList->addModelObjectType(IddObjectType::OS_Construction_InternalSource, "Internal Source Constructions");
+  myModelList->addModelObjectType(IddObjectType::OS_Construction_AirBoundary, "Air Boundary Constructions");
   myModelList->addModelObjectType(IddObjectType::OS_Construction, "Constructions");
   myModelList->addModelObjectType(IddObjectType::OS_Schedule_VariableInterval, "Variable Interval Schedules");
   myModelList->addModelObjectType(IddObjectType::OS_Schedule_FixedInterval, "Fixed Interval Schedules");
@@ -602,6 +606,7 @@ void MainRightColumnController::configureForLoadsSubTab(int subTabID)
   myLibraryList->addModelObjectType(IddObjectType::OS_Construction_FfactorGroundFloor, "F-factor Ground Floor Constructions");
   myLibraryList->addModelObjectType(IddObjectType::OS_Construction_CfactorUndergroundWall, "C-factor Underground Wall Constructions");
   myLibraryList->addModelObjectType(IddObjectType::OS_Construction_InternalSource, "Internal Source Constructions");
+  myLibraryList->addModelObjectType(IddObjectType::OS_Construction_AirBoundary, "Air Boundary Constructions");
   myLibraryList->addModelObjectType(IddObjectType::OS_Construction, "Constructions");
   myLibraryList->addModelObjectType(IddObjectType::OS_InternalMass_Definition, "Internal Mass Definitions");
   myLibraryList->addModelObjectType(IddObjectType::OS_OtherEquipment_Definition, "Other Equipment Definitions");
@@ -730,6 +735,7 @@ void MainRightColumnController::configureForFacilitySubTab(int subTabID)
   myModelList->addModelObjectType(IddObjectType::OS_Construction_FfactorGroundFloor, "F-factor Ground Floor Constructions");
   myModelList->addModelObjectType(IddObjectType::OS_Construction_CfactorUndergroundWall, "C-factor Underground Wall Constructions");
   myModelList->addModelObjectType(IddObjectType::OS_Construction_InternalSource, "Internal Source Constructions");
+  myModelList->addModelObjectType(IddObjectType::OS_Construction_AirBoundary, "Air Boundary Constructions");
   myModelList->addModelObjectType(IddObjectType::OS_Construction, "Constructions");
   myModelList->addModelObjectType(IddObjectType::OS_Schedule_VariableInterval, "Variable Interval Schedules");
   myModelList->addModelObjectType(IddObjectType::OS_Schedule_FixedInterval, "Fixed Interval Schedules");
@@ -778,6 +784,7 @@ void MainRightColumnController::configureForFacilitySubTab(int subTabID)
   myLibraryList->addModelObjectType(IddObjectType::OS_Construction_FfactorGroundFloor, "F-factor Ground Floor Constructions");
   myLibraryList->addModelObjectType(IddObjectType::OS_Construction_CfactorUndergroundWall, "C-factor Underground Wall Constructions");
   myLibraryList->addModelObjectType(IddObjectType::OS_Construction_InternalSource, "Internal Source Constructions");
+  myLibraryList->addModelObjectType(IddObjectType::OS_Construction_AirBoundary, "Air Boundary Constructions");
   myLibraryList->addModelObjectType(IddObjectType::OS_Construction, "Constructions");
   myLibraryList->addModelObjectType(IddObjectType::OS_Schedule_VariableInterval, "Variable Interval Schedules");
   myLibraryList->addModelObjectType(IddObjectType::OS_Schedule_FixedInterval, "Fixed Interval Schedules");
@@ -833,6 +840,7 @@ void MainRightColumnController::configureForSpacesSubTab(int subTabID)
   myModelList->addModelObjectType(IddObjectType::OS_Construction_FfactorGroundFloor, "F-factor Ground Floor Constructions");
   myModelList->addModelObjectType(IddObjectType::OS_Construction_CfactorUndergroundWall, "C-factor Underground Wall Constructions");
   myModelList->addModelObjectType(IddObjectType::OS_Construction_InternalSource, "Internal Source Constructions");
+  myModelList->addModelObjectType(IddObjectType::OS_Construction_AirBoundary, "Air Boundary Constructions");
   myModelList->addModelObjectType(IddObjectType::OS_Construction, "Constructions");
   myModelList->addModelObjectType(IddObjectType::OS_Schedule_VariableInterval, "Variable Interval Schedules");
   myModelList->addModelObjectType(IddObjectType::OS_Schedule_FixedInterval, "Fixed Interval Schedules");
@@ -887,6 +895,7 @@ void MainRightColumnController::configureForSpacesSubTab(int subTabID)
   myLibraryList->addModelObjectType(IddObjectType::OS_Construction_FfactorGroundFloor, "F-factor Ground Floor Constructions");
   myLibraryList->addModelObjectType(IddObjectType::OS_Construction_CfactorUndergroundWall, "C-factor Underground Wall Constructions");
   myLibraryList->addModelObjectType(IddObjectType::OS_Construction_InternalSource, "Internal Source Constructions");
+  myLibraryList->addModelObjectType(IddObjectType::OS_Construction_AirBoundary, "Air Boundary Constructions");
   myLibraryList->addModelObjectType(IddObjectType::OS_Construction, "Constructions");
   myLibraryList->addModelObjectType(IddObjectType::OS_Schedule_VariableInterval, "Variable Interval Schedules");
   myLibraryList->addModelObjectType(IddObjectType::OS_Schedule_FixedInterval, "Fixed Interval Schedules");

--- a/src/openstudio_lib/openstudio.qrc
+++ b/src/openstudio_lib/openstudio.qrc
@@ -369,6 +369,7 @@
     <file>images/mini_icons/mini_ht_coil_dx_vari.png</file>
     <file>images/mini_icons/construct_inter_source.png</file>
     <file>images/mini_icons/construction.png</file>
+    <file>images/mini_icons/construction_air_boundary.png</file>
     <file>images/mini_icons/construction_gnd.png</file>
     <file>images/mini_icons/construction_undergnd.png</file>
     <file>images/mini_icons/cool_coil.png</file>

--- a/src/openstudio_lib/test/IconLibrary_GTest.cpp
+++ b/src/openstudio_lib/test/IconLibrary_GTest.cpp
@@ -56,6 +56,7 @@ TEST_F(OpenStudioLibFixture, IconLibrary_Icon)
   iddObjectTypes.push_back(IddObjectType::OS_Coil_Heating_Gas);
   iddObjectTypes.push_back(IddObjectType::OS_Coil_Heating_Water);
   //iddObjectTypes.push_back(IddObjectType::OS_Construction);
+  //iddObjectTypes.push_back(IddObjectType::OS_Construction_AirBoundary);
   //iddObjectTypes.push_back(IddObjectType::OS_Construction_CfactorUndergroundWall);
   //iddObjectTypes.push_back(IddObjectType::OS_Construction_FfactorGroundFloor);
   //iddObjectTypes.push_back(IddObjectType::OS_Construction_InternalSource);


### PR DESCRIPTION
Fix #97 

#37 had missed a few things from [Adding ConstructionAirBoundary, replaces previous method of represent...](https://github.com/NREL/OpenStudio/commit/bf17b66549ddc5c7a5badb7f0a84d12b93b44e81#diff-634c1073e5b19fb9bb0f160608351717)

With fix, icon is correctly displayed:

![image](https://user-images.githubusercontent.com/5479063/78686466-58c65380-78f3-11ea-8d61-1b1694622519.png)


New entry in MainRightColumnController is added:

![image](https://user-images.githubusercontent.com/5479063/78686496-654aac00-78f3-11ea-8db4-3979cca13701.png)

And the modification of the ConstructionAirBoundary shows the correct, specific, edit pane via `showAirBoundaryInspector`:

![image](https://user-images.githubusercontent.com/5479063/78686548-7a273f80-78f3-11ea-94e9-fd7ada366765.png)
